### PR TITLE
fix: validate qubit indices, gate dims, and param counts

### DIFF
--- a/gpu/jax_qsim/circuit.py
+++ b/gpu/jax_qsim/circuit.py
@@ -14,83 +14,113 @@ class Circuit:
         if param_index is not None:
             self.num_params = max(self.num_params, param_index + 1)
 
+    def _validate_targets(self, targets: list[int]):
+        for t in targets:
+            if not 0 <= t < self.num_qubits:
+                raise ValueError(
+                    f'Qubit index {t} is out of range for a {self.num_qubits}-qubit '
+                    f'circuit (valid range is [0, {self.num_qubits})).')
+        if len(set(targets)) != len(targets):
+            raise ValueError(f'Gate targets must be distinct qubits, got {targets}')
+
     def h(self, qubit: int):
+        self._validate_targets([qubit])
         self.gates.append({'type': 'static', 'matrix': ops.H, 'targets': [qubit]})
         return self
 
     def x(self, qubit: int):
+        self._validate_targets([qubit])
         self.gates.append({'type': 'static', 'matrix': ops.X, 'targets': [qubit]})
         return self
 
     def y(self, qubit: int):
+        self._validate_targets([qubit])
         self.gates.append({'type': 'static', 'matrix': ops.Y, 'targets': [qubit]})
         return self
 
     def z(self, qubit: int):
+        self._validate_targets([qubit])
         self.gates.append({'type': 'static', 'matrix': ops.Z, 'targets': [qubit]})
         return self
 
     def s(self, qubit: int):
+        self._validate_targets([qubit])
         self.gates.append({'type': 'static', 'matrix': ops.S, 'targets': [qubit]})
         return self
 
     def t(self, qubit: int):
+        self._validate_targets([qubit])
         self.gates.append({'type': 'static', 'matrix': ops.T, 'targets': [qubit]})
         return self
 
     def cnot(self, control: int, target: int):
+        self._validate_targets([control, target])
         self.gates.append({'type': 'static', 'matrix': ops.CNOT, 'targets': [control, target]})
         return self
 
     def cz(self, control: int, target: int):
+        self._validate_targets([control, target])
         self.gates.append({'type': 'static', 'matrix': ops.CZ, 'targets': [control, target]})
         return self
 
     def swap(self, qubit1: int, qubit2: int):
+        self._validate_targets([qubit1, qubit2])
         self.gates.append({'type': 'static', 'matrix': ops.SWAP, 'targets': [qubit1, qubit2]})
         return self
 
     def rx(self, qubit: int, param_index: int):
+        self._validate_targets([qubit])
         self._register_param(param_index)
         self.gates.append({'type': 'parameterized', 'gate_func': ops.rx, 'targets': [qubit], 'param_index': param_index})
         return self
 
     def ry(self, qubit: int, param_index: int):
+        self._validate_targets([qubit])
         self._register_param(param_index)
         self.gates.append({'type': 'parameterized', 'gate_func': ops.ry, 'targets': [qubit], 'param_index': param_index})
         return self
 
     def rz(self, qubit: int, param_index: int):
+        self._validate_targets([qubit])
         self._register_param(param_index)
         self.gates.append({'type': 'parameterized', 'gate_func': ops.rz, 'targets': [qubit], 'param_index': param_index})
         return self
 
     def phase_shift(self, qubit: int, param_index: int):
+        self._validate_targets([qubit])
         self._register_param(param_index)
         self.gates.append({'type': 'parameterized', 'gate_func': ops.phase_shift, 'targets': [qubit], 'param_index': param_index})
         return self
 
     def crx(self, control: int, target: int, param_index: int):
+        self._validate_targets([control, target])
         self._register_param(param_index)
         self.gates.append({'type': 'parameterized', 'gate_func': ops.crx, 'targets': [control, target], 'param_index': param_index})
         return self
 
     def cry(self, control: int, target: int, param_index: int):
+        self._validate_targets([control, target])
         self._register_param(param_index)
         self.gates.append({'type': 'parameterized', 'gate_func': ops.cry, 'targets': [control, target], 'param_index': param_index})
         return self
 
     def crz(self, control: int, target: int, param_index: int):
+        self._validate_targets([control, target])
         self._register_param(param_index)
         self.gates.append({'type': 'parameterized', 'gate_func': ops.crz, 'targets': [control, target], 'param_index': param_index})
         return self
 
     def cphase(self, control: int, target: int, param_index: int):
+        self._validate_targets([control, target])
         self._register_param(param_index)
         self.gates.append({'type': 'parameterized', 'gate_func': ops.cphase, 'targets': [control, target], 'param_index': param_index})
         return self
 
     def run(self, params: jnp.ndarray, initial_state: jnp.ndarray=None) -> jnp.ndarray:
+        if params.shape[0] < self.num_params:
+            raise ValueError(
+                f'Circuit requires {self.num_params} parameter(s), but only '
+                f'{params.shape[0]} were provided.')
         if initial_state is None:
             state = zero_state(self.num_qubits)
         else:

--- a/gpu/jax_qsim/core.py
+++ b/gpu/jax_qsim/core.py
@@ -2,6 +2,8 @@ import jax
 import jax.numpy as jnp
 
 def zero_state(num_qubits: int) -> jnp.ndarray:
+    if num_qubits < 1:
+        raise ValueError(f'num_qubits must be a positive integer, got {num_qubits}')
     state = jnp.zeros(2 ** num_qubits, dtype=jnp.complex64)
     state = state.at[0].set(1.0 + 0j)
     return state.reshape((2,) * num_qubits)
@@ -9,6 +11,20 @@ def zero_state(num_qubits: int) -> jnp.ndarray:
 def apply_gate(state: jnp.ndarray, gate_matrix: jnp.ndarray, targets: list[int]) -> jnp.ndarray:
     num_qubits = state.ndim
     k = len(targets)
+    if k == 0:
+        raise ValueError('apply_gate requires at least one target qubit.')
+    if len(set(targets)) != k:
+        raise ValueError(f'Duplicate target qubits are not allowed: {targets}')
+    for t in targets:
+        if not 0 <= t < num_qubits:
+            raise ValueError(
+                f'Target qubit {t} is out of range for a {num_qubits}-qubit state '
+                f'(valid range is [0, {num_qubits}))')
+    expected_dim = 2 ** k
+    if gate_matrix.shape != (expected_dim, expected_dim):
+        raise ValueError(
+            f'Gate matrix shape {gate_matrix.shape} does not match {k} target '
+            f'qubit(s); expected a ({expected_dim}, {expected_dim}) matrix.')
     gate_tensor = gate_matrix.reshape((2,) * (2 * k))
     gate_contract_axes = list(range(k, 2 * k))
     state_contract_axes = list(targets)

--- a/gpu/jax_qsim/observables.py
+++ b/gpu/jax_qsim/observables.py
@@ -9,6 +9,12 @@ class PauliString:
         self.term = term
 
     def apply(self, state: jnp.ndarray) -> jnp.ndarray:
+        num_qubits = state.ndim
+        for qubit in self.term:
+            if not 0 <= qubit < num_qubits:
+                raise ValueError(
+                    f'PauliString references qubit {qubit}, but the state only '
+                    f'has {num_qubits} qubit(s) (valid range is [0, {num_qubits})).')
         out_state = state
         for qubit, op_char in sorted(self.term.items()):
             if op_char == 'X':

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,64 @@
+import jax.numpy as jnp
+import pytest
+from jax_qsim import Circuit, zero_state, apply_gate
+import jax_qsim.ops as ops
+from jax_qsim.observables import PauliString
+
+
+def test_zero_state_rejects_non_positive_qubits():
+    with pytest.raises(ValueError):
+        zero_state(0)
+    with pytest.raises(ValueError):
+        zero_state(-1)
+
+
+def test_apply_gate_rejects_out_of_range_target():
+    state = zero_state(2)
+    with pytest.raises(ValueError):
+        apply_gate(state, ops.X, [5])
+    with pytest.raises(ValueError):
+        apply_gate(state, ops.X, [-1])
+
+
+def test_apply_gate_rejects_duplicate_targets():
+    state = zero_state(2)
+    with pytest.raises(ValueError):
+        apply_gate(state, ops.CNOT, [0, 0])
+
+
+def test_apply_gate_rejects_mismatched_matrix_dimension():
+    state = zero_state(2)
+    with pytest.raises(ValueError):
+        # ops.CNOT is a 4x4 matrix but only one target is given.
+        apply_gate(state, ops.CNOT, [0])
+
+
+def test_circuit_rejects_out_of_range_qubit():
+    c = Circuit(num_qubits=2)
+    with pytest.raises(ValueError):
+        c.h(5)
+    with pytest.raises(ValueError):
+        c.cnot(0, 3)
+
+
+def test_circuit_rejects_duplicate_targets():
+    c = Circuit(num_qubits=2)
+    with pytest.raises(ValueError):
+        c.cnot(0, 0)
+    with pytest.raises(ValueError):
+        c.swap(1, 1)
+
+
+def test_circuit_run_rejects_insufficient_params():
+    c = Circuit(num_qubits=1)
+    c.ry(0, param_index=0)
+    c.rz(0, param_index=1)
+    with pytest.raises(ValueError):
+        c.run(jnp.array([0.5]))
+
+
+def test_pauli_string_rejects_out_of_range_qubit():
+    state = zero_state(2)
+    obs = PauliString({5: 'Z'})
+    with pytest.raises(ValueError):
+        obs.apply(state)


### PR DESCRIPTION
## Summary

Adds input validation to the core jax_qsim engine (gpu/jax_qsim/). Previously several error paths either raised cryptic jnp shape/index errors or silently produced wrong results instead of a clear message:

- pply_gate: now rejects empty target lists, duplicate targets, out-of-range target qubits, and gate matrices whose dimension doesn't match the number of targets.
- zero_state: now rejects non-positive 
um_qubits.
- Circuit: every gate-builder method (h, x, y, z, s, 	, cnot, cz, swap, x, y, z, phase_shift, crx, cry, crz, cphase) now validates qubit indices at build time instead of failing later inside un(). un() also checks the provided params array is long enough for the circuit's registered parameters.
- PauliString.apply: now rejects qubit indices outside the state's actual qubit count (previously this silently corrupted the tensor shape instead of raising).

## Testing

- All 7 existing tests in 	ests/ still pass unchanged.
- Added 	ests/test_validation.py (8 new tests) covering each validation path added above.
- Ran pytest tests/ -v locally: 15/15 passed.

## Notes

This only adds validation/guardrails -- no changes to gate semantics, numerics, or the public API signatures. Safe, backwards-compatible change.